### PR TITLE
Remove inline declarations

### DIFF
--- a/compiler/styxc_ast/src/lib.rs
+++ b/compiler/styxc_ast/src/lib.rs
@@ -361,7 +361,7 @@ pub struct Ident {
 #[derive(Debug, PartialEq)]
 pub enum StmtKind {
     /// A declaration.
-    Declaration(Vec<Declaration>),
+    Declaration(Declaration),
     /// An assignment.
     Assignment(Assignment),
     // A loop block.

--- a/compiler/styxc_ir/src/lib.rs
+++ b/compiler/styxc_ir/src/lib.rs
@@ -94,6 +94,8 @@ impl IrTranslator {
         // cleanup context and finalize definitions
         self.module.clear_context(&mut self.ctx);
         // return the address of the main function
+
+        todo!()
     }
 }
 
@@ -120,10 +122,8 @@ impl<'a> FunctionTranslator<'a> {
     }
 
     /// Translate a declaration.
-    fn translate_declaration(&mut self, declaration: Vec<Declaration>) {
-        for decl in declaration {
-            
-        }
+    fn translate_declaration(&mut self, declaration: Declaration) -> Value {
+        todo!()       
     }
 
     /// Translate an expression.

--- a/compiler/styxc_parser/src/grammar.pest
+++ b/compiler/styxc_parser/src/grammar.pest
@@ -129,11 +129,11 @@ bin_exp = { bin_exp_inner ~ (bin_op ~ bin_exp_inner)+ }
 expression = { bin_exp | literal | ident | block }
 
 assignment_op = { "=" | "+=" | "-=" | "*=" | "/=" | "%=" | "&=" | "|=" | "^=" }
-assignment = !{ (ident ~ ",")* ~ ident ~ assignment_op ~ (expression ~ ",")* ~ expression }
+assignment = !{ ident ~ assignment_op ~ expression }
 
 declaration_type = { ":" ~ ident }
-declaration = !{ "let" ~ (ident ~ ",")* ~ ident ~ declaration_type? ~ "=" ~ (expression ~ ",")* ~ expression }
-mut_declaration = !{ "mut" ~ (ident ~ ",")* ~ ident ~ declaration_type? ~ "=" ~ (expression ~ ",")* ~ expression }
+declaration = !{ "let" ~ ident ~ declaration_type? ~ "=" ~ expression }
+mut_declaration = !{ "mut" ~ ident ~ declaration_type? ~ "=" ~ expression }
 
 func_return = !{ "return" ~ expression }
 func_param = !{ ident ~ ":" ~ ident }

--- a/compiler/styxc_parser/src/lib.rs
+++ b/compiler/styxc_parser/src/lib.rs
@@ -92,55 +92,65 @@ impl StyxParser {
         &mut self,
         pair: Pair<Rule>,
         mutability: Mutability,
-    ) -> Result<Vec<Declaration>, Box<dyn Error>> {
+    ) -> Result<Declaration, Box<dyn Error>> {
+        // This code is related to inline assignemnts and declarations - see https://github.com/SkyezerFox/styx/issues/7.
+        // let mut inner = pair.into_inner();
+        // let mut idents = vec![];
+        // let mut exprs = vec![];
+        // // concatenate all idents
+        // loop {
+        //     let next = inner.next().unwrap();
+        //     if matches!(next.as_rule(), Rule::expression) {
+        //         exprs.push(next);
+        //         break;
+        //     }
+        //     idents.push(next);
+        // }
+        // // concatenate all exprs
+        // while let Some(expr) = inner.next() {
+        //     exprs.push(expr);
+        // }
+        // // panic if mismatching number of exprs and idents
+        // let single_expr = exprs.len() == 1;
+        // if !single_expr && exprs.len() != idents.len() {
+        //     panic!();
+        // }
+        // // iterate over idents and set
+        // let mut index = 0;
+        // let results: Vec<Result<Declaration, Box<dyn Error>>> = idents
+        //     .into_iter()
+        //     .map(|ident| {
+        //         let value = if single_expr {
+        //             &exprs[0]
+        //         } else {
+        //             &exprs[index]
+        //         };
+        //         index += 1;
+        //         Ok(Declaration {
+        //             ident: self.parse_identifier(ident)?,
+        //             mutability,
+        //             value: self.parse_expression(value.clone())?,
+        //         })
+        //     })
+        //     .collect();
+        // // iterate over results and find errors
+        // let mut out = vec![];
+        // for result in results {
+        //     if !result.is_ok() {
+        //         return Err(result.unwrap_err());
+        //     }
+        //     out.push(result.unwrap());
+        // }
+        
         let mut inner = pair.into_inner();
-        let mut idents = vec![];
-        let mut exprs = vec![];
-        // concatenate all idents
-        loop {
-            let next = inner.next().unwrap();
-            if matches!(next.as_rule(), Rule::expression) {
-                exprs.push(next);
-                break;
-            }
-            idents.push(next);
-        }
-        // concatenate all exprs
-        while let Some(expr) = inner.next() {
-            exprs.push(expr);
-        }
-        // panic if mismatching number of exprs and idents
-        let single_expr = exprs.len() == 1;
-        if !single_expr && exprs.len() != idents.len() {
-            panic!();
-        }
-        // iterate over idents and set
-        let mut index = 0;
-        let results: Vec<Result<Declaration, Box<dyn Error>>> = idents
-            .into_iter()
-            .map(|ident| {
-                let value = if single_expr {
-                    &exprs[0]
-                } else {
-                    &exprs[index]
-                };
-                index += 1;
-                Ok(Declaration {
-                    ident: self.parse_identifier(ident)?,
-                    mutability,
-                    value: self.parse_expression(value.clone())?,
-                })
-            })
-            .collect();
-        // iterate over results and find errors
-        let mut out = vec![];
-        for result in results {
-            if !result.is_ok() {
-                return Err(result.unwrap_err());
-            }
-            out.push(result.unwrap());
-        }
-        Ok(out)
+        let ident = inner.next().unwrap();
+        let value = inner.next().unwrap();
+
+        Ok(Declaration {
+            ident: self.parse_identifier(ident)?,
+            mutability,
+            value: self.parse_expression(value)?,
+        })
     }
 
     /// Parse an assignment.
@@ -278,7 +288,7 @@ mod tests {
                 stmts: vec![
                     Stmt {
                         id: 1,
-                        kind: StmtKind::Declaration(vec![Declaration {
+                        kind: StmtKind::Declaration(Declaration {
                             ident: Ident {
                                 id: 0,
                                 name: "x".into(),
@@ -290,7 +300,7 @@ mod tests {
                                 kind: LiteralKind::Int(1),
                                 span: Span(8, 9),
                             })
-                        }])
+                        })
                     },
                     Stmt {
                         id: 3,
@@ -323,7 +333,7 @@ mod tests {
                 modules: vec![],
                 stmts: vec![Stmt {
                     id: 1,
-                    kind: StmtKind::Declaration(vec![Declaration {
+                    kind: StmtKind::Declaration(Declaration {
                         ident: Ident {
                             id: 0,
                             name: "x".into(),
@@ -346,7 +356,7 @@ mod tests {
                             })
                             .into(),
                         })
-                    }])
+                    })
                 }]
             }
         )
@@ -362,7 +372,7 @@ mod tests {
                 modules: vec![],
                 stmts: vec![Stmt {
                     id: 1,
-                    kind: StmtKind::Declaration(vec![Declaration {
+                    kind: StmtKind::Declaration(Declaration {
                         ident: Ident {
                             id: 0,
                             name: "x".into(),
@@ -407,7 +417,7 @@ mod tests {
                             })
                             .into()
                         })
-                    }])
+                    })
                 }]
             }
         )


### PR DESCRIPTION
See #7 - these kinds of statements cannot feasibly be parsed until the language has developed further.