### PR TITLE
Add Rc<str> to Span

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           components: clippy
           override: true
       - run: cargo install clippy-sarif sarif-fmt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
       - uses: Swatinem/rust-cache@v1
       - name: Run crate tests
         working-directory: compiler/${{ matrix.dir }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
+          override: true
       - uses: Swatinem/rust-cache@v1
       - name: Run crate tests
         working-directory: compiler/${{ matrix.dir }}

--- a/compiler/fluxc_parser/src/expr/block_expr.rs
+++ b/compiler/fluxc_parser/src/expr/block_expr.rs
@@ -31,13 +31,13 @@ mod tests {
         let root = context.create_span();
         // {}
         let expected =
-            Node { id: 0, span: root.restrict_range(0, 1), value: Block { stmts: vec![] } };
+            Node { id: 0, span: root.restrict_range(0, 2), value: Block { stmts: vec![] } };
         let result = FluxParser::parse(Rule::block, "{}").unwrap().next().unwrap();
         let result = Block::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
         // { }
         let expected =
-            Node { id: 1, span: root.restrict_range(0, 2), value: Block { stmts: vec![] } };
+            Node { id: 1, span: root.restrict_range(0, 3), value: Block { stmts: vec![] } };
         let result = FluxParser::parse(Rule::block, "{ }").unwrap().next().unwrap();
         let result = Block::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
@@ -64,31 +64,31 @@ mod tests {
         // }
         let expected = Node {
             id: 0,
-            span: root.restrict_range(0, 26),
+            span: root.restrict_range(0, 27),
             value: Block {
                 stmts: vec![
                     Node {
                         id: 1,
-                        span: root.restrict_range(6, 13),
+                        span: root.restrict_range(6, 14),
                         value: Stmt::Expr(Node {
                             id: 2,
-                            span: root.restrict_range(6, 12),
+                            span: root.restrict_range(6, 13),
                             value: Expr::Literal(Node {
                                 id: 3,
-                                span: root.restrict_range(6, 12),
+                                span: root.restrict_range(6, 13),
                                 value: Literal::String("hello".to_string()),
                             }),
                         }),
                     },
                     Node {
                         id: 4,
-                        span: root.restrict_range(18, 25),
+                        span: root.restrict_range(18, 26),
                         value: Stmt::Expr(Node {
                             id: 5,
-                            span: root.restrict_range(18, 24),
+                            span: root.restrict_range(18, 25),
                             value: Expr::Literal(Node {
                                 id: 6,
-                                span: root.restrict_range(18, 24),
+                                span: root.restrict_range(18, 25),
                                 value: Literal::String("world".to_string()),
                             }),
                         }),

--- a/compiler/fluxc_parser/src/expr/block_expr.rs
+++ b/compiler/fluxc_parser/src/expr/block_expr.rs
@@ -1,15 +1,11 @@
-use fluxc_ast::{Block, Node, Stmt};
-use fluxc_errors::CompilerError;
+use fluxc_ast::{Block, Stmt};
 use pest::iterators::Pair;
 
-use crate::{Context, Parse, Rule};
+use crate::{Context, PResult, Parse, Rule};
 
 impl Parse for Block {
     #[tracing::instrument]
-    fn parse<'i>(
-        input: Pair<'i, Rule>,
-        context: &mut Context,
-    ) -> PResult<Self> {
+    fn parse<'i>(input: Pair<'i, Rule>, context: &mut Context) -> PResult<Self> {
         debug_assert_eq!(input.as_rule(), Rule::block);
         let node = context.new_empty(input.as_span());
         // parse child statements
@@ -24,7 +20,6 @@ impl Parse for Block {
 #[cfg(test)]
 mod tests {
     use fluxc_ast::{Block, Expr, Literal, Node, Stmt};
-    use fluxc_span::Span;
     use pest::Parser;
     use pretty_assertions::assert_eq;
 
@@ -32,19 +27,23 @@ mod tests {
 
     #[test]
     fn parse_empty_block() {
-        let mut context = Context::default();
+        let mut context = Context::from_str("{}");
+        let root = context.create_span();
         // {}
-        let expected = Node { id: 0, span: Span::new(0, 1), value: Block { stmts: vec![] } };
+        let expected =
+            Node { id: 0, span: root.restrict_range(0, 1), value: Block { stmts: vec![] } };
         let result = FluxParser::parse(Rule::block, "{}").unwrap().next().unwrap();
         let result = Block::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
         // { }
-        let expected = Node { id: 1, span: Span::new(0, 2), value: Block { stmts: vec![] } };
+        let expected =
+            Node { id: 1, span: root.restrict_range(0, 2), value: Block { stmts: vec![] } };
         let result = FluxParser::parse(Rule::block, "{ }").unwrap().next().unwrap();
         let result = Block::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
         // {\n\t\n}
-        let expected = Node { id: 2, span: Span::new(0, 4), value: Block { stmts: vec![] } };
+        let expected =
+            Node { id: 2, span: root.restrict_range(0, 4), value: Block { stmts: vec![] } };
         let result = FluxParser::parse(Rule::block, "{\n\t\n}").unwrap().next().unwrap();
         let result = Block::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
@@ -52,38 +51,44 @@ mod tests {
 
     #[test]
     fn parse_block_with_stmts() {
-        let mut context = Context::default();
+        let mut context = Context::from_str(
+            r#"{
+	x = 1;
+	y = 2;
+}"#,
+        );
+        let root = context.create_span();
         // {
         //     "hello"
         //     "world"
         // }
         let expected = Node {
             id: 0,
-            span: Span::new(0, 26),
+            span: root.restrict_range(0, 26),
             value: Block {
                 stmts: vec![
                     Node {
                         id: 1,
-                        span: Span::new(6, 13),
+                        span: root.restrict_range(6, 13),
                         value: Stmt::Expr(Node {
                             id: 2,
-                            span: Span::new(6, 12),
+                            span: root.restrict_range(6, 12),
                             value: Expr::Literal(Node {
                                 id: 3,
-                                span: Span::new(6, 12),
+                                span: root.restrict_range(6, 12),
                                 value: Literal::String("hello".to_string()),
                             }),
                         }),
                     },
                     Node {
                         id: 4,
-                        span: Span::new(18, 25),
+                        span: root.restrict_range(18, 25),
                         value: Stmt::Expr(Node {
                             id: 5,
-                            span: Span::new(18, 24),
+                            span: root.restrict_range(18, 24),
                             value: Expr::Literal(Node {
                                 id: 6,
-                                span: Span::new(18, 24),
+                                span: root.restrict_range(18, 24),
                                 value: Literal::String("world".to_string()),
                             }),
                         }),

--- a/compiler/fluxc_parser/src/expr/block_expr.rs
+++ b/compiler/fluxc_parser/src/expr/block_expr.rs
@@ -9,7 +9,7 @@ impl Parse for Block {
     fn parse<'i>(
         input: Pair<'i, Rule>,
         context: &mut Context,
-    ) -> Result<Node<Self>, CompilerError> {
+    ) -> PResult<Self> {
         debug_assert_eq!(input.as_rule(), Rule::block);
         let node = context.new_empty(input.as_span());
         // parse child statements

--- a/compiler/fluxc_parser/src/expr/control/conditional.rs
+++ b/compiler/fluxc_parser/src/expr/control/conditional.rs
@@ -1,7 +1,7 @@
 use fluxc_ast::{Block, Conditional, Expr, IfStmt};
 use pest::iterators::Pair;
 
-use crate::{Context, Parse, Rule, PResult};
+use crate::{Context, PResult, Parse, Rule};
 
 impl Parse for Conditional {
     #[tracing::instrument]
@@ -58,38 +58,39 @@ mod tests {
 
     #[test]
     fn parse_single_if() {
-        let mut context = Context::default();
+        let mut context = Context::from_str("if true { 1 }");
+        let root = Span::from_str("if true { 1 }");
         // if true { 1 }
         let expected = Node {
             id: 0,
-            span: Span::new(0, 12),
+            span: root.restrict_range(0, 12),
             value: Conditional {
                 if_stmt: Node {
                     id: 1,
-                    span: Span::new(0, 12),
+                    span: root.restrict_range(0, 12),
                     value: IfStmt {
                         condition: Box::new(Node {
                             id: 2,
-                            span: Span::new(3, 6),
+                            span: root.restrict_range(3, 6),
                             value: Expr::Literal(Node {
                                 id: 3,
-                                span: Span::new(3, 6),
+                                span: root.restrict_range(3, 6),
                                 value: Literal::Bool(true),
                             }),
                         }),
                         value: Node {
                             id: 4,
-                            span: Span::new(8, 12),
+                            span: root.restrict_range(8, 12),
                             value: Block {
                                 stmts: vec![Node {
                                     id: 5,
-                                    span: Span::new(10, 11),
+                                    span: root.restrict_range(10, 11),
                                     value: Stmt::Expr(Node {
                                         id: 6,
-                                        span: Span::new(10, 10),
+                                        span: root.restrict_range(10, 10),
                                         value: Expr::Literal(Node {
                                             id: 7,
-                                            span: Span::new(10, 10),
+                                            span: root.restrict_range(10, 10),
                                             value: Literal::Int(1),
                                         }),
                                     }),
@@ -112,38 +113,39 @@ mod tests {
 
     #[test]
     fn parse_if_else() {
-        let mut context = Context::default();
+        let mut context = Context::from_str("if true { 1 } else { 2 }");
+        let root = Span::from_str("if true { 1 } else { 2 }");
         // if true { 1 } else { 2 }
         let expected = Node {
             id: 0,
-            span: Span::new(0, 23),
+            span: root.restrict_range(0, 23),
             value: Conditional {
                 if_stmt: Node {
                     id: 1,
-                    span: Span::new(0, 12),
+                    span: root.restrict_range(0, 12),
                     value: IfStmt {
                         condition: Box::new(Node {
                             id: 2,
-                            span: Span::new(3, 6),
+                            span: root.restrict_range(3, 6),
                             value: Expr::Literal(Node {
                                 id: 3,
-                                span: Span::new(3, 6),
+                                span: root.restrict_range(3, 6),
                                 value: Literal::Bool(true),
                             }),
                         }),
                         value: Node {
                             id: 4,
-                            span: Span::new(8, 12),
+                            span: root.restrict_range(8, 12),
                             value: Block {
                                 stmts: vec![Node {
                                     id: 5,
-                                    span: Span::new(10, 11),
+                                    span: root.restrict_range(10, 11),
                                     value: Stmt::Expr(Node {
                                         id: 6,
-                                        span: Span::new(10, 10),
+                                        span: root.restrict_range(10, 10),
                                         value: Expr::Literal(Node {
                                             id: 7,
-                                            span: Span::new(10, 10),
+                                            span: root.restrict_range(10, 10),
                                             value: Literal::Int(1),
                                         }),
                                     }),
@@ -155,17 +157,17 @@ mod tests {
                 else_ifs: vec![],
                 else_stmt: Some(Node {
                     id: 8,
-                    span: Span::new(19, 23),
+                    span: root.restrict_range(19, 23),
                     value: Block {
                         stmts: vec![Node {
                             id: 9,
-                            span: Span::new(21, 22),
+                            span: root.restrict_range(21, 22),
                             value: Stmt::Expr(Node {
                                 id: 10,
-                                span: Span::new(21, 21),
+                                span: root.restrict_range(21, 21),
                                 value: Expr::Literal(Node {
                                     id: 11,
-                                    span: Span::new(21, 21),
+                                    span: root.restrict_range(21, 21),
                                     value: Literal::Int(2),
                                 }),
                             }),
@@ -187,38 +189,39 @@ mod tests {
 
     #[test]
     fn parse_if_else_if() {
-        let mut context = Context::default();
+        let mut context = Context::from_str("if true { 1 } else if false { 2 }");
+        let root = Span::from_str("if true { 1 } else if false { 2 }");
         // if true { 1 } else if false { 2 }
         let expected = Node {
             id: 0,
-            span: Span::new(0, 32),
+            span: root.restrict_range(0, 32),
             value: Conditional {
                 if_stmt: Node {
                     id: 1,
-                    span: Span::new(0, 12),
+                    span: root.restrict_range(0, 12),
                     value: IfStmt {
                         condition: Box::new(Node {
                             id: 2,
-                            span: Span::new(3, 6),
+                            span: root.restrict_range(3, 6),
                             value: Expr::Literal(Node {
                                 id: 3,
-                                span: Span::new(3, 6),
+                                span: root.restrict_range(3, 6),
                                 value: Literal::Bool(true),
                             }),
                         }),
                         value: Node {
                             id: 4,
-                            span: Span::new(8, 12),
+                            span: root.restrict_range(8, 12),
                             value: Block {
                                 stmts: vec![Node {
                                     id: 5,
-                                    span: Span::new(10, 11),
+                                    span: root.restrict_range(10, 11),
                                     value: Stmt::Expr(Node {
                                         id: 6,
-                                        span: Span::new(10, 10),
+                                        span: root.restrict_range(10, 10),
                                         value: Expr::Literal(Node {
                                             id: 7,
-                                            span: Span::new(10, 10),
+                                            span: root.restrict_range(10, 10),
                                             value: Literal::Int(1),
                                         }),
                                     }),
@@ -229,30 +232,30 @@ mod tests {
                 },
                 else_ifs: vec![Node {
                     id: 8,
-                    span: Span::new(14, 32),
+                    span: root.restrict_range(14, 32),
                     value: IfStmt {
                         condition: Box::new(Node {
                             id: 9,
-                            span: Span::new(22, 26),
+                            span: root.restrict_range(22, 26),
                             value: Expr::Literal(Node {
                                 id: 10,
-                                span: Span::new(22, 26),
+                                span: root.restrict_range(22, 26),
                                 value: Literal::Bool(false),
                             }),
                         }),
                         value: Node {
                             id: 11,
-                            span: Span::new(28, 32),
+                            span: root.restrict_range(28, 32),
                             value: Block {
                                 stmts: vec![Node {
                                     id: 12,
-                                    span: Span::new(30, 31),
+                                    span: root.restrict_range(30, 31),
                                     value: Stmt::Expr(Node {
                                         id: 13,
-                                        span: Span::new(30, 30),
+                                        span: root.restrict_range(30, 30),
                                         value: Expr::Literal(Node {
                                             id: 14,
-                                            span: Span::new(30, 30),
+                                            span: root.restrict_range(30, 30),
                                             value: Literal::Int(2),
                                         }),
                                     }),
@@ -277,38 +280,39 @@ mod tests {
 
     #[test]
     fn parse_if_else_if_else() {
-        let mut context = Context::default();
+        let mut context = Context::from_str("if true { 1 } else if false { 2 } else { 3 }");
+        let root = Span::from_str("if true { 1 } else if false { 2 } else { 3 }");
         // if true { 1 } else if false { 2 } else { 3 }
         let expected = Node {
             id: 0,
-            span: Span::new(0, 43),
+            span: root.restrict_range(0, 43),
             value: Conditional {
                 if_stmt: Node {
                     id: 1,
-                    span: Span::new(0, 12),
+                    span: root.restrict_range(0, 12),
                     value: IfStmt {
                         condition: Box::new(Node {
                             id: 2,
-                            span: Span::new(3, 6),
+                            span: root.restrict_range(3, 6),
                             value: Expr::Literal(Node {
                                 id: 3,
-                                span: Span::new(3, 6),
+                                span: root.restrict_range(3, 6),
                                 value: Literal::Bool(true),
                             }),
                         }),
                         value: Node {
                             id: 4,
-                            span: Span::new(8, 12),
+                            span: root.restrict_range(8, 12),
                             value: Block {
                                 stmts: vec![Node {
                                     id: 5,
-                                    span: Span::new(10, 11),
+                                    span: root.restrict_range(10, 11),
                                     value: Stmt::Expr(Node {
                                         id: 6,
-                                        span: Span::new(10, 10),
+                                        span: root.restrict_range(10, 10),
                                         value: Expr::Literal(Node {
                                             id: 7,
-                                            span: Span::new(10, 10),
+                                            span: root.restrict_range(10, 10),
                                             value: Literal::Int(1),
                                         }),
                                     }),
@@ -319,30 +323,30 @@ mod tests {
                 },
                 else_ifs: vec![Node {
                     id: 8,
-                    span: Span::new(14, 32),
+                    span: root.restrict_range(14, 32),
                     value: IfStmt {
                         condition: Box::new(Node {
                             id: 9,
-                            span: Span::new(22, 26),
+                            span: root.restrict_range(22, 26),
                             value: Expr::Literal(Node {
                                 id: 10,
-                                span: Span::new(22, 26),
+                                span: root.restrict_range(22, 26),
                                 value: Literal::Bool(false),
                             }),
                         }),
                         value: Node {
                             id: 11,
-                            span: Span::new(28, 32),
+                            span: root.restrict_range(28, 32),
                             value: Block {
                                 stmts: vec![Node {
                                     id: 12,
-                                    span: Span::new(30, 31),
+                                    span: root.restrict_range(30, 31),
                                     value: Stmt::Expr(Node {
                                         id: 13,
-                                        span: Span::new(30, 30),
+                                        span: root.restrict_range(30, 30),
                                         value: Expr::Literal(Node {
                                             id: 14,
-                                            span: Span::new(30, 30),
+                                            span: root.restrict_range(30, 30),
                                             value: Literal::Int(2),
                                         }),
                                     }),
@@ -353,17 +357,17 @@ mod tests {
                 }],
                 else_stmt: Some(Node {
                     id: 15,
-                    span: Span::new(39, 43),
+                    span: root.restrict_range(39, 43),
                     value: Block {
                         stmts: vec![Node {
                             id: 16,
-                            span: Span::new(41, 42),
+                            span: root.restrict_range(41, 42),
                             value: Stmt::Expr(Node {
                                 id: 17,
-                                span: Span::new(41, 41),
+                                span: root.restrict_range(41, 41),
                                 value: Expr::Literal(Node {
                                     id: 18,
-                                    span: Span::new(41, 41),
+                                    span: root.restrict_range(41, 41),
                                     value: Literal::Int(3),
                                 }),
                             }),

--- a/compiler/fluxc_parser/src/expr/control/conditional.rs
+++ b/compiler/fluxc_parser/src/expr/control/conditional.rs
@@ -63,34 +63,34 @@ mod tests {
         // if true { 1 }
         let expected = Node {
             id: 0,
-            span: root.restrict_range(0, 12),
+            span: root.restrict_range(0, 13),
             value: Conditional {
                 if_stmt: Node {
                     id: 1,
-                    span: root.restrict_range(0, 12),
+                    span: root.restrict_range(0, 13),
                     value: IfStmt {
                         condition: Box::new(Node {
                             id: 2,
-                            span: root.restrict_range(3, 6),
+                            span: root.restrict_range(3, 7),
                             value: Expr::Literal(Node {
                                 id: 3,
-                                span: root.restrict_range(3, 6),
+                                span: root.restrict_range(3, 7),
                                 value: Literal::Bool(true),
                             }),
                         }),
                         value: Node {
                             id: 4,
-                            span: root.restrict_range(8, 12),
+                            span: root.restrict_range(8, 13),
                             value: Block {
                                 stmts: vec![Node {
                                     id: 5,
-                                    span: root.restrict_range(10, 11),
+                                    span: root.restrict_range(10, 12),
                                     value: Stmt::Expr(Node {
                                         id: 6,
-                                        span: root.restrict_range(10, 10),
+                                        span: root.restrict_range(10, 11),
                                         value: Expr::Literal(Node {
                                             id: 7,
-                                            span: root.restrict_range(10, 10),
+                                            span: root.restrict_range(10, 11),
                                             value: Literal::Int(1),
                                         }),
                                     }),
@@ -118,34 +118,34 @@ mod tests {
         // if true { 1 } else { 2 }
         let expected = Node {
             id: 0,
-            span: root.restrict_range(0, 23),
+            span: root.restrict_range(0, 24),
             value: Conditional {
                 if_stmt: Node {
                     id: 1,
-                    span: root.restrict_range(0, 12),
+                    span: root.restrict_range(0, 13),
                     value: IfStmt {
                         condition: Box::new(Node {
                             id: 2,
-                            span: root.restrict_range(3, 6),
+                            span: root.restrict_range(3, 7),
                             value: Expr::Literal(Node {
                                 id: 3,
-                                span: root.restrict_range(3, 6),
+                                span: root.restrict_range(3, 7),
                                 value: Literal::Bool(true),
                             }),
                         }),
                         value: Node {
                             id: 4,
-                            span: root.restrict_range(8, 12),
+                            span: root.restrict_range(8, 13),
                             value: Block {
                                 stmts: vec![Node {
                                     id: 5,
-                                    span: root.restrict_range(10, 11),
+                                    span: root.restrict_range(10, 12),
                                     value: Stmt::Expr(Node {
                                         id: 6,
-                                        span: root.restrict_range(10, 10),
+                                        span: root.restrict_range(10, 11),
                                         value: Expr::Literal(Node {
                                             id: 7,
-                                            span: root.restrict_range(10, 10),
+                                            span: root.restrict_range(10, 11),
                                             value: Literal::Int(1),
                                         }),
                                     }),
@@ -157,17 +157,17 @@ mod tests {
                 else_ifs: vec![],
                 else_stmt: Some(Node {
                     id: 8,
-                    span: root.restrict_range(19, 23),
+                    span: root.restrict_range(19, 24),
                     value: Block {
                         stmts: vec![Node {
                             id: 9,
-                            span: root.restrict_range(21, 22),
+                            span: root.restrict_range(21, 23),
                             value: Stmt::Expr(Node {
                                 id: 10,
-                                span: root.restrict_range(21, 21),
+                                span: root.restrict_range(21, 22),
                                 value: Expr::Literal(Node {
                                     id: 11,
-                                    span: root.restrict_range(21, 21),
+                                    span: root.restrict_range(21, 22),
                                     value: Literal::Int(2),
                                 }),
                             }),
@@ -194,34 +194,34 @@ mod tests {
         // if true { 1 } else if false { 2 }
         let expected = Node {
             id: 0,
-            span: root.restrict_range(0, 32),
+            span: root.restrict_range(0, 33),
             value: Conditional {
                 if_stmt: Node {
                     id: 1,
-                    span: root.restrict_range(0, 12),
+                    span: root.restrict_range(0, 13),
                     value: IfStmt {
                         condition: Box::new(Node {
                             id: 2,
-                            span: root.restrict_range(3, 6),
+                            span: root.restrict_range(3, 7),
                             value: Expr::Literal(Node {
                                 id: 3,
-                                span: root.restrict_range(3, 6),
+                                span: root.restrict_range(3, 7),
                                 value: Literal::Bool(true),
                             }),
                         }),
                         value: Node {
                             id: 4,
-                            span: root.restrict_range(8, 12),
+                            span: root.restrict_range(8, 13),
                             value: Block {
                                 stmts: vec![Node {
                                     id: 5,
-                                    span: root.restrict_range(10, 11),
+                                    span: root.restrict_range(10, 12),
                                     value: Stmt::Expr(Node {
                                         id: 6,
-                                        span: root.restrict_range(10, 10),
+                                        span: root.restrict_range(10, 11),
                                         value: Expr::Literal(Node {
                                             id: 7,
-                                            span: root.restrict_range(10, 10),
+                                            span: root.restrict_range(10, 11),
                                             value: Literal::Int(1),
                                         }),
                                     }),
@@ -232,30 +232,30 @@ mod tests {
                 },
                 else_ifs: vec![Node {
                     id: 8,
-                    span: root.restrict_range(14, 32),
+                    span: root.restrict_range(14, 33),
                     value: IfStmt {
                         condition: Box::new(Node {
                             id: 9,
-                            span: root.restrict_range(22, 26),
+                            span: root.restrict_range(22, 27),
                             value: Expr::Literal(Node {
                                 id: 10,
-                                span: root.restrict_range(22, 26),
+                                span: root.restrict_range(22, 27),
                                 value: Literal::Bool(false),
                             }),
                         }),
                         value: Node {
                             id: 11,
-                            span: root.restrict_range(28, 32),
+                            span: root.restrict_range(28, 33),
                             value: Block {
                                 stmts: vec![Node {
                                     id: 12,
-                                    span: root.restrict_range(30, 31),
+                                    span: root.restrict_range(30, 32),
                                     value: Stmt::Expr(Node {
                                         id: 13,
-                                        span: root.restrict_range(30, 30),
+                                        span: root.restrict_range(30, 31),
                                         value: Expr::Literal(Node {
                                             id: 14,
-                                            span: root.restrict_range(30, 30),
+                                            span: root.restrict_range(30, 31),
                                             value: Literal::Int(2),
                                         }),
                                     }),
@@ -285,34 +285,34 @@ mod tests {
         // if true { 1 } else if false { 2 } else { 3 }
         let expected = Node {
             id: 0,
-            span: root.restrict_range(0, 43),
+            span: root.restrict_range(0, 44),
             value: Conditional {
                 if_stmt: Node {
                     id: 1,
-                    span: root.restrict_range(0, 12),
+                    span: root.restrict_range(0, 13),
                     value: IfStmt {
                         condition: Box::new(Node {
                             id: 2,
-                            span: root.restrict_range(3, 6),
+                            span: root.restrict_range(3, 7),
                             value: Expr::Literal(Node {
                                 id: 3,
-                                span: root.restrict_range(3, 6),
+                                span: root.restrict_range(3, 7),
                                 value: Literal::Bool(true),
                             }),
                         }),
                         value: Node {
                             id: 4,
-                            span: root.restrict_range(8, 12),
+                            span: root.restrict_range(8, 13),
                             value: Block {
                                 stmts: vec![Node {
                                     id: 5,
-                                    span: root.restrict_range(10, 11),
+                                    span: root.restrict_range(10, 12),
                                     value: Stmt::Expr(Node {
                                         id: 6,
-                                        span: root.restrict_range(10, 10),
+                                        span: root.restrict_range(10, 11),
                                         value: Expr::Literal(Node {
                                             id: 7,
-                                            span: root.restrict_range(10, 10),
+                                            span: root.restrict_range(10, 11),
                                             value: Literal::Int(1),
                                         }),
                                     }),
@@ -323,30 +323,30 @@ mod tests {
                 },
                 else_ifs: vec![Node {
                     id: 8,
-                    span: root.restrict_range(14, 32),
+                    span: root.restrict_range(14, 33),
                     value: IfStmt {
                         condition: Box::new(Node {
                             id: 9,
-                            span: root.restrict_range(22, 26),
+                            span: root.restrict_range(22, 27),
                             value: Expr::Literal(Node {
                                 id: 10,
-                                span: root.restrict_range(22, 26),
+                                span: root.restrict_range(22, 27),
                                 value: Literal::Bool(false),
                             }),
                         }),
                         value: Node {
                             id: 11,
-                            span: root.restrict_range(28, 32),
+                            span: root.restrict_range(28, 33),
                             value: Block {
                                 stmts: vec![Node {
                                     id: 12,
-                                    span: root.restrict_range(30, 31),
+                                    span: root.restrict_range(30, 32),
                                     value: Stmt::Expr(Node {
                                         id: 13,
-                                        span: root.restrict_range(30, 30),
+                                        span: root.restrict_range(30, 31),
                                         value: Expr::Literal(Node {
                                             id: 14,
-                                            span: root.restrict_range(30, 30),
+                                            span: root.restrict_range(30, 31),
                                             value: Literal::Int(2),
                                         }),
                                     }),
@@ -357,17 +357,17 @@ mod tests {
                 }],
                 else_stmt: Some(Node {
                     id: 15,
-                    span: root.restrict_range(39, 43),
+                    span: root.restrict_range(39, 44),
                     value: Block {
                         stmts: vec![Node {
                             id: 16,
-                            span: root.restrict_range(41, 42),
+                            span: root.restrict_range(41, 43),
                             value: Stmt::Expr(Node {
                                 id: 17,
-                                span: root.restrict_range(41, 41),
+                                span: root.restrict_range(41, 42),
                                 value: Expr::Literal(Node {
                                     id: 18,
-                                    span: root.restrict_range(41, 41),
+                                    span: root.restrict_range(41, 42),
                                     value: Literal::Int(3),
                                 }),
                             }),

--- a/compiler/fluxc_parser/src/expr/control/conditional.rs
+++ b/compiler/fluxc_parser/src/expr/control/conditional.rs
@@ -1,12 +1,11 @@
-use fluxc_ast::{Block, Conditional, Expr, IfStmt, Node};
-use fluxc_errors::CompilerError;
+use fluxc_ast::{Block, Conditional, Expr, IfStmt};
 use pest::iterators::Pair;
 
-use crate::{Context, Parse, Rule};
+use crate::{Context, Parse, Rule, PResult};
 
 impl Parse for Conditional {
     #[tracing::instrument]
-    fn parse<'i>(input: Pair<'i, Rule>, ctx: &mut Context) -> Result<Node<Self>, CompilerError> {
+    fn parse<'i>(input: Pair<'i, Rule>, ctx: &mut Context) -> PResult<Self> {
         debug_assert_eq!(input.as_rule(), Rule::conditional_stmt);
         let node = ctx.new_empty(input.as_span());
         let mut inner = input.into_inner();
@@ -34,7 +33,7 @@ impl Parse for Conditional {
 
 impl Parse for IfStmt {
     #[tracing::instrument]
-    fn parse<'i>(input: Pair<'i, Rule>, ctx: &mut Context) -> Result<Node<Self>, CompilerError> {
+    fn parse<'i>(input: Pair<'i, Rule>, ctx: &mut Context) -> PResult<Self> {
         debug_assert!(input.as_rule() == Rule::if_stmt || input.as_rule() == Rule::else_if_stmt);
         let node = ctx.new_empty(input.as_span());
         // unwrap into inner

--- a/compiler/fluxc_parser/src/expr/control/loop_expr.rs
+++ b/compiler/fluxc_parser/src/expr/control/loop_expr.rs
@@ -1,12 +1,11 @@
-use fluxc_ast::{Block, Loop, Node};
-use fluxc_errors::CompilerError;
+use fluxc_ast::{Block, Loop};
 use pest::iterators::Pair;
 
-use crate::{Context, Parse, Rule};
+use crate::{Context, Parse, Rule, PResult};
 
 impl Parse for Loop {
     #[tracing::instrument]
-    fn parse<'i>(input: Pair<'i, Rule>, ctx: &mut Context) -> Result<Node<Self>, CompilerError> {
+    fn parse<'i>(input: Pair<'i, Rule>, ctx: &mut Context) -> PResult<Self> {
         debug_assert_eq!(input.as_rule(), Rule::loop_stmt);
         let node = ctx.new_empty(input.as_span());
         let inner = input.into_inner();

--- a/compiler/fluxc_parser/src/expr/control/loop_expr.rs
+++ b/compiler/fluxc_parser/src/expr/control/loop_expr.rs
@@ -1,7 +1,7 @@
 use fluxc_ast::{Block, Loop};
 use pest::iterators::Pair;
 
-use crate::{Context, Parse, Rule, PResult};
+use crate::{Context, PResult, Parse, Rule};
 
 impl Parse for Loop {
     #[tracing::instrument]
@@ -24,14 +24,19 @@ mod tests {
 
     #[test]
     fn parse_loop_expr() {
-        let mut context = Context::default();
+        let mut context = Context::from_str("loop {}");
+        let root = Span::from_str("loop {}");
         // loop {}
         let expected = Node {
             id: 0,
-            span: Span::new(0, 6),
+            span: root.restrict_range(0, 6),
             value: Loop {
                 name: None,
-                block: Node { id: 1, span: Span::new(5, 6), value: Block { stmts: vec![] } },
+                block: Node {
+                    id: 1,
+                    span: root.restrict_range(5, 6),
+                    value: Block { stmts: vec![] },
+                },
             },
         };
         let actual = Loop::parse(

--- a/compiler/fluxc_parser/src/expr/control/loop_expr.rs
+++ b/compiler/fluxc_parser/src/expr/control/loop_expr.rs
@@ -29,12 +29,12 @@ mod tests {
         // loop {}
         let expected = Node {
             id: 0,
-            span: root.restrict_range(0, 6),
+            span: root.restrict_range(0, 7),
             value: Loop {
                 name: None,
                 block: Node {
                     id: 1,
-                    span: root.restrict_range(5, 6),
+                    span: root.restrict_range(5, 7),
                     value: Block { stmts: vec![] },
                 },
             },
@@ -44,6 +44,6 @@ mod tests {
             &mut context,
         )
         .unwrap();
-        assert_eq!(actual, expected);
+        assert_eq!(expected, actual);
     }
 }

--- a/compiler/fluxc_parser/src/expr/control/match_expr.rs
+++ b/compiler/fluxc_parser/src/expr/control/match_expr.rs
@@ -45,14 +45,14 @@ mod tests {
         // match x {}
         let expected = Node {
             id: 0,
-            span: root.restrict_range(0, 9),
+            span: root.restrict_range(0, 10),
             value: Match {
                 expr: Box::new(Node {
                     id: 1,
-                    span: root.restrict_range(6, 6),
+                    span: root.restrict_range(6, 7),
                     value: Expr::Ident(Node {
                         id: 2,
-                        span: root.restrict_range(6, 6),
+                        span: root.restrict_range(6, 7),
                         value: "x".to_string(),
                     }),
                 }),
@@ -74,37 +74,37 @@ mod tests {
         // match x { 1 -> 1, 2 -> 2 }
         let expected = Node {
             id: 0,
-            span: root.restrict_range(0, 25),
+            span: root.restrict_range(0, 26),
             value: Match {
                 expr: Box::new(Node {
                     id: 1,
-                    span: root.restrict_range(6, 6),
+                    span: root.restrict_range(6, 7),
                     value: Expr::Ident(Node {
                         id: 2,
-                        span: root.restrict_range(6, 6),
+                        span: root.restrict_range(6, 7),
                         value: "x".to_string(),
                     }),
                 }),
                 cases: vec![
                     Node {
                         id: 3,
-                        span: root.restrict_range(10, 15),
+                        span: root.restrict_range(10, 16),
                         value: MatchBranch {
                             pattern: Node {
                                 id: 4,
-                                span: root.restrict_range(10, 10),
+                                span: root.restrict_range(10, 11),
                                 value: Expr::Literal(Node {
                                     id: 5,
-                                    span: root.restrict_range(10, 10),
+                                    span: root.restrict_range(10, 11),
                                     value: Literal::Int(1),
                                 }),
                             },
                             value: Node {
                                 id: 6,
-                                span: root.restrict_range(15, 15),
+                                span: root.restrict_range(15, 16),
                                 value: Expr::Literal(Node {
                                     id: 7,
-                                    span: root.restrict_range(15, 15),
+                                    span: root.restrict_range(15, 16),
                                     value: Literal::Int(1),
                                 }),
                             },
@@ -112,23 +112,23 @@ mod tests {
                     },
                     Node {
                         id: 8,
-                        span: root.restrict_range(18, 23),
+                        span: root.restrict_range(18, 24),
                         value: MatchBranch {
                             pattern: Node {
                                 id: 9,
-                                span: root.restrict_range(18, 18),
+                                span: root.restrict_range(18, 19),
                                 value: Expr::Literal(Node {
                                     id: 10,
-                                    span: root.restrict_range(18, 18),
+                                    span: root.restrict_range(18, 19),
                                     value: Literal::Int(2),
                                 }),
                             },
                             value: Node {
                                 id: 11,
-                                span: root.restrict_range(23, 23),
+                                span: root.restrict_range(23, 24),
                                 value: Expr::Literal(Node {
                                     id: 12,
-                                    span: root.restrict_range(23, 23),
+                                    span: root.restrict_range(23, 24),
                                     value: Literal::Int(2),
                                 }),
                             },

--- a/compiler/fluxc_parser/src/expr/control/match_expr.rs
+++ b/compiler/fluxc_parser/src/expr/control/match_expr.rs
@@ -1,15 +1,14 @@
-use fluxc_ast::{Expr, Match, MatchBranch, Node};
-use fluxc_errors::CompilerError;
+use fluxc_ast::{Expr, Match, MatchBranch};
 use pest::iterators::Pair;
 
-use crate::{Context, Parse, Rule};
+use crate::{Context, Parse, Rule, PResult};
 
 impl Parse for Match {
     #[tracing::instrument]
     fn parse<'i>(
         input: Pair<'i, Rule>,
         context: &mut Context,
-    ) -> Result<Node<Self>, CompilerError> {
+    ) -> PResult<Self> {
         debug_assert_eq!(input.as_rule(), Rule::match_expr);
         let node = context.new_empty(input.as_span());
         let mut inner = input.into_inner();
@@ -25,7 +24,7 @@ impl Parse for MatchBranch {
     fn parse<'i>(
         input: Pair<'i, Rule>,
         context: &mut Context,
-    ) -> Result<Node<Self>, CompilerError> {
+    ) -> PResult<Self> {
         debug_assert_eq!(input.as_rule(), Rule::match_branch);
         let node = context.new_empty(input.as_span());
         let mut inner = input.into_inner();

--- a/compiler/fluxc_parser/src/expr/control/match_expr.rs
+++ b/compiler/fluxc_parser/src/expr/control/match_expr.rs
@@ -1,14 +1,11 @@
 use fluxc_ast::{Expr, Match, MatchBranch};
 use pest::iterators::Pair;
 
-use crate::{Context, Parse, Rule, PResult};
+use crate::{Context, PResult, Parse, Rule};
 
 impl Parse for Match {
     #[tracing::instrument]
-    fn parse<'i>(
-        input: Pair<'i, Rule>,
-        context: &mut Context,
-    ) -> PResult<Self> {
+    fn parse<'i>(input: Pair<'i, Rule>, context: &mut Context) -> PResult<Self> {
         debug_assert_eq!(input.as_rule(), Rule::match_expr);
         let node = context.new_empty(input.as_span());
         let mut inner = input.into_inner();
@@ -21,10 +18,7 @@ impl Parse for Match {
 
 impl Parse for MatchBranch {
     #[tracing::instrument]
-    fn parse<'i>(
-        input: Pair<'i, Rule>,
-        context: &mut Context,
-    ) -> PResult<Self> {
+    fn parse<'i>(input: Pair<'i, Rule>, context: &mut Context) -> PResult<Self> {
         debug_assert_eq!(input.as_rule(), Rule::match_branch);
         let node = context.new_empty(input.as_span());
         let mut inner = input.into_inner();
@@ -46,18 +40,19 @@ mod tests {
 
     #[test]
     fn parse_empty_match_expr() {
-        let mut context = Context::default();
+        let mut context = Context::from_str("match x {}");
+        let root = Span::from_str("match x {}");
         // match x {}
         let expected = Node {
             id: 0,
-            span: Span::new(0, 9),
+            span: root.restrict_range(0, 9),
             value: Match {
                 expr: Box::new(Node {
                     id: 1,
-                    span: Span::new(6, 6),
+                    span: root.restrict_range(6, 6),
                     value: Expr::Ident(Node {
                         id: 2,
-                        span: Span::new(6, 6),
+                        span: root.restrict_range(6, 6),
                         value: "x".to_string(),
                     }),
                 }),
@@ -74,41 +69,42 @@ mod tests {
 
     #[test]
     fn parse_match_expr() {
-        let mut context = Context::default();
+        let mut context = Context::from_str("match x { 1 -> 1, 2 -> 2 }");
+        let root = Span::from_str("match x { 1 -> 1, 2 -> 2 }");
         // match x { 1 -> 1, 2 -> 2 }
         let expected = Node {
             id: 0,
-            span: Span::new(0, 25),
+            span: root.restrict_range(0, 25),
             value: Match {
                 expr: Box::new(Node {
                     id: 1,
-                    span: Span::new(6, 6),
+                    span: root.restrict_range(6, 6),
                     value: Expr::Ident(Node {
                         id: 2,
-                        span: Span::new(6, 6),
+                        span: root.restrict_range(6, 6),
                         value: "x".to_string(),
                     }),
                 }),
                 cases: vec![
                     Node {
                         id: 3,
-                        span: Span::new(10, 15),
+                        span: root.restrict_range(10, 15),
                         value: MatchBranch {
                             pattern: Node {
                                 id: 4,
-                                span: Span::new(10, 10),
+                                span: root.restrict_range(10, 10),
                                 value: Expr::Literal(Node {
                                     id: 5,
-                                    span: Span::new(10, 10),
+                                    span: root.restrict_range(10, 10),
                                     value: Literal::Int(1),
                                 }),
                             },
                             value: Node {
                                 id: 6,
-                                span: Span::new(15, 15),
+                                span: root.restrict_range(15, 15),
                                 value: Expr::Literal(Node {
                                     id: 7,
-                                    span: Span::new(15, 15),
+                                    span: root.restrict_range(15, 15),
                                     value: Literal::Int(1),
                                 }),
                             },
@@ -116,23 +112,23 @@ mod tests {
                     },
                     Node {
                         id: 8,
-                        span: Span::new(18, 23),
+                        span: root.restrict_range(18, 23),
                         value: MatchBranch {
                             pattern: Node {
                                 id: 9,
-                                span: Span::new(18, 18),
+                                span: root.restrict_range(18, 18),
                                 value: Expr::Literal(Node {
                                     id: 10,
-                                    span: Span::new(18, 18),
+                                    span: root.restrict_range(18, 18),
                                     value: Literal::Int(2),
                                 }),
                             },
                             value: Node {
                                 id: 11,
-                                span: Span::new(23, 23),
+                                span: root.restrict_range(23, 23),
                                 value: Expr::Literal(Node {
                                     id: 12,
-                                    span: Span::new(23, 23),
+                                    span: root.restrict_range(23, 23),
                                     value: Literal::Int(2),
                                 }),
                             },

--- a/compiler/fluxc_parser/src/expr/control/while_expr.rs
+++ b/compiler/fluxc_parser/src/expr/control/while_expr.rs
@@ -1,7 +1,7 @@
 use fluxc_ast::{Block, Expr, While};
 use pest::iterators::Pair;
 
-use crate::{Context, Parse, Rule, PResult};
+use crate::{Context, PResult, Parse, Rule};
 
 impl Parse for While {
     #[tracing::instrument]
@@ -27,22 +27,27 @@ mod tests {
 
     #[test]
     fn parse_empty_while_stmt() {
-        let mut context = Context::default();
+        let mut context = Context::from_str("while x {}");
+        let root = Span::from_str("while x {}");
         // while x {}
         let expected = Node {
             id: 0,
-            span: Span::new(0, 9),
+            span: root.restrict_range(0, 9),
             value: While {
                 condition: Box::new(Node {
                     id: 1,
-                    span: Span::new(6, 6),
+                    span: root.restrict_range(6, 6),
                     value: Expr::Ident(Node {
                         id: 2,
-                        span: Span::new(6, 6),
+                        span: root.restrict_range(6, 6),
                         value: "x".to_string(),
                     }),
                 }),
-                block: Node { id: 3, span: Span::new(8, 9), value: Block { stmts: vec![] } },
+                block: Node {
+                    id: 3,
+                    span: root.restrict_range(8, 9),
+                    value: Block { stmts: vec![] },
+                },
             },
         };
         let actual = While::parse(
@@ -55,34 +60,35 @@ mod tests {
 
     #[test]
     fn parse_while_stmt() {
-        let mut context = Context::default();
+        let mut context = Context::from_str("while x { \"hello world!\" }");
+        let root = Span::from_str("while x { \"hello world!\" }");
         // while x { "hello world!" }
         let expected = Node {
             id: 0,
-            span: Span::new(0, 25),
+            span: root.restrict_range(0, 25),
             value: While {
                 condition: Box::new(Node {
                     id: 1,
-                    span: Span::new(6, 6),
+                    span: root.restrict_range(6, 6),
                     value: Expr::Ident(Node {
                         id: 2,
-                        span: Span::new(6, 6),
+                        span: root.restrict_range(6, 6),
                         value: "x".to_string(),
                     }),
                 }),
                 block: Node {
                     id: 3,
-                    span: Span::new(8, 25),
+                    span: root.restrict_range(8, 25),
                     value: Block {
                         stmts: vec![Node {
                             id: 4,
-                            span: Span::new(10, 24),
+                            span: root.restrict_range(10, 24),
                             value: Stmt::Expr(Node {
                                 id: 5,
-                                span: Span::new(10, 23),
+                                span: root.restrict_range(10, 23),
                                 value: Expr::Literal(Node {
                                     id: 6,
-                                    span: Span::new(10, 23),
+                                    span: root.restrict_range(10, 23),
                                     value: Literal::String("hello world!".to_string()),
                                 }),
                             }),

--- a/compiler/fluxc_parser/src/expr/control/while_expr.rs
+++ b/compiler/fluxc_parser/src/expr/control/while_expr.rs
@@ -1,12 +1,11 @@
-use fluxc_ast::{Block, Expr, Node, While};
-use fluxc_errors::CompilerError;
+use fluxc_ast::{Block, Expr, While};
 use pest::iterators::Pair;
 
-use crate::{Context, Parse, Rule};
+use crate::{Context, Parse, Rule, PResult};
 
 impl Parse for While {
     #[tracing::instrument]
-    fn parse<'i>(input: Pair<'i, Rule>, ctx: &mut Context) -> Result<Node<Self>, CompilerError> {
+    fn parse<'i>(input: Pair<'i, Rule>, ctx: &mut Context) -> PResult<Self> {
         debug_assert_eq!(input.as_rule(), Rule::while_stmt);
         let node = ctx.new_empty(input.as_span());
         let mut inner = input.into_inner();

--- a/compiler/fluxc_parser/src/expr/control/while_expr.rs
+++ b/compiler/fluxc_parser/src/expr/control/while_expr.rs
@@ -32,20 +32,20 @@ mod tests {
         // while x {}
         let expected = Node {
             id: 0,
-            span: root.restrict_range(0, 9),
+            span: root.restrict_range(0, 10),
             value: While {
                 condition: Box::new(Node {
                     id: 1,
-                    span: root.restrict_range(6, 6),
+                    span: root.restrict_range(6, 7),
                     value: Expr::Ident(Node {
                         id: 2,
-                        span: root.restrict_range(6, 6),
+                        span: root.restrict_range(6, 7),
                         value: "x".to_string(),
                     }),
                 }),
                 block: Node {
                     id: 3,
-                    span: root.restrict_range(8, 9),
+                    span: root.restrict_range(8, 10),
                     value: Block { stmts: vec![] },
                 },
             },
@@ -65,30 +65,30 @@ mod tests {
         // while x { "hello world!" }
         let expected = Node {
             id: 0,
-            span: root.restrict_range(0, 25),
+            span: root.restrict_range(0, 26),
             value: While {
                 condition: Box::new(Node {
                     id: 1,
-                    span: root.restrict_range(6, 6),
+                    span: root.restrict_range(6, 7),
                     value: Expr::Ident(Node {
                         id: 2,
-                        span: root.restrict_range(6, 6),
+                        span: root.restrict_range(6, 7),
                         value: "x".to_string(),
                     }),
                 }),
                 block: Node {
                     id: 3,
-                    span: root.restrict_range(8, 25),
+                    span: root.restrict_range(8, 26),
                     value: Block {
                         stmts: vec![Node {
                             id: 4,
-                            span: root.restrict_range(10, 24),
+                            span: root.restrict_range(10, 25),
                             value: Stmt::Expr(Node {
                                 id: 5,
-                                span: root.restrict_range(10, 23),
+                                span: root.restrict_range(10, 24),
                                 value: Expr::Literal(Node {
                                     id: 6,
-                                    span: root.restrict_range(10, 23),
+                                    span: root.restrict_range(10, 24),
                                     value: Literal::String("hello world!".to_string()),
                                 }),
                             }),

--- a/compiler/fluxc_parser/src/expr/literal.rs
+++ b/compiler/fluxc_parser/src/expr/literal.rs
@@ -42,7 +42,6 @@ impl Parse for Literal {
 #[cfg(test)]
 mod tests {
     use fluxc_ast::{Literal, Node};
-    use fluxc_span::Span;
     use pest::Parser;
     use pretty_assertions::assert_eq;
 
@@ -50,15 +49,17 @@ mod tests {
 
     #[test]
     fn parse_literal_int() {
+        // 123
         let mut ctx = Context::from_str("123");
         let root = ctx.create_span();
-        // 123
-        let expected = Node { id: 0, span: root.restrict_range(0, 2), value: Literal::Int(123) };
+        let expected = Node { id: 0, span: root.restrict_range(0, 3), value: Literal::Int(123) };
         let result = FluxParser::parse(Rule::literal, "123").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut ctx).unwrap();
         assert_eq!(expected, result);
         // -321
-        let expected = Node { id: 1, span: root.restrict_range(0, 3), value: Literal::Int(-321) };
+		let mut ctx = Context::from_str("-321");
+        let root = ctx.create_span();
+        let expected = Node { id: 0, span: root.restrict_range(0, 4), value: Literal::Int(-321) };
         let result = FluxParser::parse(Rule::literal, "-321").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut ctx).unwrap();
         assert_eq!(expected, result);
@@ -66,17 +67,19 @@ mod tests {
 
     #[test]
     fn parse_literal_float() {
+        // 123.456
         let mut context = Context::from_str("123.456");
         let root = context.create_span();
-        // 123.456
         let expected =
-            Node { id: 0, span: root.restrict_range(0, 6), value: Literal::Float(123.456) };
+            Node { id: 0, span: root.restrict_range(0, 7), value: Literal::Float(123.456) };
         let result = FluxParser::parse(Rule::literal, "123.456").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
         // -123.456
+		let mut context = Context::from_str("-123.456");
+        let root = context.create_span();
         let expected =
-            Node { id: 1, span: root.restrict_range(0, 7), value: Literal::Float(-123.456) };
+            Node { id: 0, span: root.restrict_range(0, 8), value: Literal::Float(-123.456) };
         let result = FluxParser::parse(Rule::literal, "-123.456").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
@@ -84,30 +87,34 @@ mod tests {
 
     #[test]
     fn parse_literal_string() {
+		// "123"
         let mut context = Context::from_str("\"123\"");
         let root = context.create_span();
-        // "123"
         let expected = Node {
             id: 0,
-            span: root.restrict_range(0, 4),
+            span: root.restrict_range(0, 5),
             value: Literal::String("123".to_string()),
         };
         let result = FluxParser::parse(Rule::literal, "\"123\"").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
         // "hello, world!"
+   		let mut context = Context::from_str("\"hello, world!\"");
+        let root = context.create_span();
         let expected = Node {
-            id: 1,
-            span: root.restrict_range(0, 14),
+            id: 0,
+            span: root.restrict_range(0, 15),
             value: Literal::String("hello, world!".to_string()),
         };
         let result = FluxParser::parse(Rule::literal, "\"hello, world!\"").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
         // "🐺💖🐺" - 4 bytes per char, 2 trailing bytes, for a total of 14 bytes
+		let mut context = Context::from_str("\"🐺💖🐺\"");
+        let root = context.create_span();
         let expected = Node {
-            id: 2,
-            span: root.restrict_range(0, 13),
+            id: 0,
+            span: root.restrict_range(0, 14),
             value: Literal::String("🐺💖🐺".to_string()),
         };
         let result = FluxParser::parse(Rule::literal, "\"🐺💖🐺\"").unwrap().next().unwrap();
@@ -117,17 +124,17 @@ mod tests {
 
     #[test]
     fn parse_literal_bool() {
+		// true
         let mut context = Context::from_str("true");
         let root = context.create_span();
-        // true
-        let expected = Node { id: 0, span: root.restrict_range(0, 3), value: Literal::Bool(true) };
+        let expected = Node { id: 0, span: root.restrict_range(0, 4), value: Literal::Bool(true) };
         let result = FluxParser::parse(Rule::literal, "true").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
         // false
         let mut context = Context::from_str("false");
         let root = context.create_span();
-        let expected = Node { id: 1, span: root.restrict_range(0, 4), value: Literal::Bool(false) };
+        let expected = Node { id: 0, span: root.restrict_range(0, 5), value: Literal::Bool(false) };
         let result = FluxParser::parse(Rule::literal, "false").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
@@ -138,14 +145,15 @@ mod tests {
         let mut context = Context::from_str("'a'");
         let root = context.create_span();
         // 'a'
-        let expected = Node { id: 0, span: root.restrict_range(0, 2), value: Literal::Char('a') };
+        let expected = Node { id: 0, span: root.restrict_range(0, 3), value: Literal::Char('a') };
         let result = FluxParser::parse(Rule::literal, "'a'").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
         // '🐺'
         let mut context = Context::from_str("'🐺'");
+		let root = context.create_span();
         let expected =
-            Node { id: 1, span: root.restrict_range(0, 5), value: Literal::Char('🐺') };
+            Node { id: 0, span: root.restrict_range(0, 6), value: Literal::Char('🐺') };
         let result = FluxParser::parse(Rule::literal, "'🐺'").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);

--- a/compiler/fluxc_parser/src/expr/literal.rs
+++ b/compiler/fluxc_parser/src/expr/literal.rs
@@ -57,7 +57,7 @@ mod tests {
         let result = Literal::parse(result, &mut ctx).unwrap();
         assert_eq!(expected, result);
         // -321
-		let mut ctx = Context::from_str("-321");
+        let mut ctx = Context::from_str("-321");
         let root = ctx.create_span();
         let expected = Node { id: 0, span: root.restrict_range(0, 4), value: Literal::Int(-321) };
         let result = FluxParser::parse(Rule::literal, "-321").unwrap().next().unwrap();
@@ -76,7 +76,7 @@ mod tests {
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
         // -123.456
-		let mut context = Context::from_str("-123.456");
+        let mut context = Context::from_str("-123.456");
         let root = context.create_span();
         let expected =
             Node { id: 0, span: root.restrict_range(0, 8), value: Literal::Float(-123.456) };
@@ -87,7 +87,7 @@ mod tests {
 
     #[test]
     fn parse_literal_string() {
-		// "123"
+        // "123"
         let mut context = Context::from_str("\"123\"");
         let root = context.create_span();
         let expected = Node {
@@ -99,7 +99,7 @@ mod tests {
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
         // "hello, world!"
-   		let mut context = Context::from_str("\"hello, world!\"");
+        let mut context = Context::from_str("\"hello, world!\"");
         let root = context.create_span();
         let expected = Node {
             id: 0,
@@ -110,7 +110,7 @@ mod tests {
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
         // "🐺💖🐺" - 4 bytes per char, 2 trailing bytes, for a total of 14 bytes
-		let mut context = Context::from_str("\"🐺💖🐺\"");
+        let mut context = Context::from_str("\"🐺💖🐺\"");
         let root = context.create_span();
         let expected = Node {
             id: 0,
@@ -124,7 +124,7 @@ mod tests {
 
     #[test]
     fn parse_literal_bool() {
-		// true
+        // true
         let mut context = Context::from_str("true");
         let root = context.create_span();
         let expected = Node { id: 0, span: root.restrict_range(0, 4), value: Literal::Bool(true) };
@@ -151,7 +151,7 @@ mod tests {
         assert_eq!(expected, result);
         // '🐺'
         let mut context = Context::from_str("'🐺'");
-		let root = context.create_span();
+        let root = context.create_span();
         let expected =
             Node { id: 0, span: root.restrict_range(0, 6), value: Literal::Char('🐺') };
         let result = FluxParser::parse(Rule::literal, "'🐺'").unwrap().next().unwrap();

--- a/compiler/fluxc_parser/src/expr/literal.rs
+++ b/compiler/fluxc_parser/src/expr/literal.rs
@@ -1,10 +1,10 @@
 use std::error::Error;
 
-use fluxc_ast::{Literal, Node};
+use fluxc_ast::Literal;
 use fluxc_errors::CompilerError;
 use pest::iterators::Pair;
 
-use crate::{Context, Parse, Rule};
+use crate::{Context, PResult, Parse, Rule};
 
 /// Internal function to handle literal parsing failure.
 fn map_parse_error<E: Error + Sized>(parse_error: E) -> CompilerError {
@@ -13,10 +13,7 @@ fn map_parse_error<E: Error + Sized>(parse_error: E) -> CompilerError {
 
 impl Parse for Literal {
     #[tracing::instrument]
-    fn parse<'i>(
-        input: Pair<'i, Rule>,
-        context: &mut Context,
-    ) -> PResult<Self> {
+    fn parse<'i>(input: Pair<'i, Rule>, context: &mut Context) -> PResult<Self> {
         let node = context.new_empty(input.as_span());
         let inner = input.into_inner().next().unwrap();
         // match inner rule
@@ -53,29 +50,33 @@ mod tests {
 
     #[test]
     fn parse_literal_int() {
-        let mut context = Context::default();
+        let mut ctx = Context::from_str("123");
+        let root = ctx.create_span();
         // 123
-        let expected = Node { id: 0, span: Span::new(0, 2), value: Literal::Int(123) };
+        let expected = Node { id: 0, span: root.restrict_range(0, 2), value: Literal::Int(123) };
         let result = FluxParser::parse(Rule::literal, "123").unwrap().next().unwrap();
-        let result = Literal::parse(result, &mut context).unwrap();
+        let result = Literal::parse(result, &mut ctx).unwrap();
         assert_eq!(expected, result);
         // -321
-        let expected = Node { id: 1, span: Span::new(0, 3), value: Literal::Int(-321) };
+        let expected = Node { id: 1, span: root.restrict_range(0, 3), value: Literal::Int(-321) };
         let result = FluxParser::parse(Rule::literal, "-321").unwrap().next().unwrap();
-        let result = Literal::parse(result, &mut context).unwrap();
+        let result = Literal::parse(result, &mut ctx).unwrap();
         assert_eq!(expected, result);
     }
 
     #[test]
     fn parse_literal_float() {
-        let mut context = Context::default();
+        let mut context = Context::from_str("123.456");
+        let root = context.create_span();
         // 123.456
-        let expected = Node { id: 0, span: Span::new(0, 6), value: Literal::Float(123.456) };
+        let expected =
+            Node { id: 0, span: root.restrict_range(0, 6), value: Literal::Float(123.456) };
         let result = FluxParser::parse(Rule::literal, "123.456").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
         // -123.456
-        let expected = Node { id: 1, span: Span::new(0, 7), value: Literal::Float(-123.456) };
+        let expected =
+            Node { id: 1, span: root.restrict_range(0, 7), value: Literal::Float(-123.456) };
         let result = FluxParser::parse(Rule::literal, "-123.456").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
@@ -83,27 +84,32 @@ mod tests {
 
     #[test]
     fn parse_literal_string() {
-        let mut context = Context::default();
+        let mut context = Context::from_str("\"123\"");
+        let root = context.create_span();
         // "123"
-        let expected =
-            Node { id: 0, span: Span::new(0, 4), value: Literal::String("123".to_string()) };
+        let expected = Node {
+            id: 0,
+            span: root.restrict_range(0, 4),
+            value: Literal::String("123".to_string()),
+        };
         let result = FluxParser::parse(Rule::literal, "\"123\"").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
         // "hello, world!"
         let expected = Node {
             id: 1,
-            span: Span::new(0, 14),
+            span: root.restrict_range(0, 14),
             value: Literal::String("hello, world!".to_string()),
         };
         let result = FluxParser::parse(Rule::literal, "\"hello, world!\"").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
         // "🐺💖🐺" - 4 bytes per char, 2 trailing bytes, for a total of 14 bytes
-        let expected =
-            Node {
-                id: 2, span: Span::new(0, 13), value: Literal::String("🐺💖🐺".to_string())
-            };
+        let expected = Node {
+            id: 2,
+            span: root.restrict_range(0, 13),
+            value: Literal::String("🐺💖🐺".to_string()),
+        };
         let result = FluxParser::parse(Rule::literal, "\"🐺💖🐺\"").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
@@ -111,14 +117,17 @@ mod tests {
 
     #[test]
     fn parse_literal_bool() {
-        let mut context = Context::default();
+        let mut context = Context::from_str("true");
+        let root = context.create_span();
         // true
-        let expected = Node { id: 0, span: Span::new(0, 3), value: Literal::Bool(true) };
+        let expected = Node { id: 0, span: root.restrict_range(0, 3), value: Literal::Bool(true) };
         let result = FluxParser::parse(Rule::literal, "true").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
         // false
-        let expected = Node { id: 1, span: Span::new(0, 4), value: Literal::Bool(false) };
+        let mut context = Context::from_str("false");
+        let root = context.create_span();
+        let expected = Node { id: 1, span: root.restrict_range(0, 4), value: Literal::Bool(false) };
         let result = FluxParser::parse(Rule::literal, "false").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
@@ -126,14 +135,17 @@ mod tests {
 
     #[test]
     fn parse_literal_char() {
-        let mut context = Context::default();
+        let mut context = Context::from_str("'a'");
+        let root = context.create_span();
         // 'a'
-        let expected = Node { id: 0, span: Span::new(0, 2), value: Literal::Char('a') };
+        let expected = Node { id: 0, span: root.restrict_range(0, 2), value: Literal::Char('a') };
         let result = FluxParser::parse(Rule::literal, "'a'").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);
         // '🐺'
-        let expected = Node { id: 1, span: Span::new(0, 5), value: Literal::Char('🐺') };
+        let mut context = Context::from_str("'🐺'");
+        let expected =
+            Node { id: 1, span: root.restrict_range(0, 5), value: Literal::Char('🐺') };
         let result = FluxParser::parse(Rule::literal, "'🐺'").unwrap().next().unwrap();
         let result = Literal::parse(result, &mut context).unwrap();
         assert_eq!(expected, result);

--- a/compiler/fluxc_parser/src/expr/literal.rs
+++ b/compiler/fluxc_parser/src/expr/literal.rs
@@ -16,7 +16,7 @@ impl Parse for Literal {
     fn parse<'i>(
         input: Pair<'i, Rule>,
         context: &mut Context,
-    ) -> Result<Node<Self>, CompilerError> {
+    ) -> PResult<Self> {
         let node = context.new_empty(input.as_span());
         let inner = input.into_inner().next().unwrap();
         // match inner rule

--- a/compiler/fluxc_parser/src/expr/mod.rs
+++ b/compiler/fluxc_parser/src/expr/mod.rs
@@ -16,7 +16,7 @@ impl Parse for Expr {
     fn parse<'i>(
         input: Pair<'i, Rule>,
         context: &mut Context,
-    ) -> Result<Node<Self>, CompilerError> {
+    ) -> PResult<Self> {
         debug_assert_eq!(input.as_rule(), Rule::expr);
         // create node and unwrap inner rule
         let node = context.new_empty(input.as_span());

--- a/compiler/fluxc_parser/src/expr/mod.rs
+++ b/compiler/fluxc_parser/src/expr/mod.rs
@@ -9,14 +9,11 @@ pub(crate) mod control;
 pub(crate) mod literal;
 pub(crate) mod operation;
 
-use crate::{Context, Parse, Rule};
+use crate::{Context, PResult, Parse, Rule};
 
 impl Parse for Expr {
     #[tracing::instrument]
-    fn parse<'i>(
-        input: Pair<'i, Rule>,
-        context: &mut Context,
-    ) -> PResult<Self> {
+    fn parse<'i>(input: Pair<'i, Rule>, context: &mut Context) -> PResult<Self> {
         debug_assert_eq!(input.as_rule(), Rule::expr);
         // create node and unwrap inner rule
         let node = context.new_empty(input.as_span());

--- a/compiler/fluxc_parser/src/expr/operation/binary_expr.rs
+++ b/compiler/fluxc_parser/src/expr/operation/binary_expr.rs
@@ -61,7 +61,7 @@ lazy_static! {
 
 impl Parse for BinaryExpr {
     #[tracing::instrument]
-    fn parse<'i>(input: Pair<'i, Rule>, ctx: &mut Context) -> Result<Node<Self>, CompilerError> {
+    fn parse<'i>(input: Pair<'i, Rule>, ctx: &mut Context) -> PResult<Self> {
         debug_assert_eq!(input.as_rule(), Rule::binary_expr);
         let inner = input.into_inner();
         let ctx = Mutex::new(ctx);

--- a/compiler/fluxc_parser/src/expr/operation/binary_expr.rs
+++ b/compiler/fluxc_parser/src/expr/operation/binary_expr.rs
@@ -163,32 +163,32 @@ mod tests {
         // 1 * 2 + 3
         let expected = Node {
             id: 8,
-            span: root.restrict_range(0, 8),
+            span: root.restrict_range(0, 9),
             value: BinaryExpr {
                 kind: BinaryOp::Plus,
                 lhs: Box::new(Node {
                     id: 4,
-                    span: root.restrict_range(0, 4),
+                    span: root.restrict_range(0, 5),
                     value: Expr::BinaryExpr(Node {
                         id: 5,
-                        span: root.restrict_range(0, 4),
+                        span: root.restrict_range(0, 5),
                         value: BinaryExpr {
                             kind: BinaryOp::Mul,
                             lhs: Box::new(Node {
                                 id: 0,
-                                span: root.restrict_range(0, 0),
+                                span: root.restrict_range(0, 1),
                                 value: Expr::Literal(Node {
                                     id: 1,
-                                    span: root.restrict_range(0, 0),
+                                    span: root.restrict_range(0, 1),
                                     value: Literal::Int(1),
                                 }),
                             }),
                             rhs: Box::new(Node {
                                 id: 2,
-                                span: root.restrict_range(4, 4),
+                                span: root.restrict_range(4, 5),
                                 value: Expr::Literal(Node {
                                     id: 3,
-                                    span: root.restrict_range(4, 4),
+                                    span: root.restrict_range(4, 5),
                                     value: Literal::Int(2),
                                 }),
                             }),
@@ -197,10 +197,10 @@ mod tests {
                 }),
                 rhs: Box::new(Node {
                     id: 6,
-                    span: root.restrict_range(8, 8),
+                    span: root.restrict_range(8, 9),
                     value: Expr::Literal(Node {
                         id: 7,
-                        span: root.restrict_range(8, 8),
+                        span: root.restrict_range(8, 9),
                         value: Literal::Int(3),
                     }),
                 }),

--- a/compiler/fluxc_parser/src/expr/operation/unary_expr.rs
+++ b/compiler/fluxc_parser/src/expr/operation/unary_expr.rs
@@ -96,15 +96,15 @@ mod tests {
         // x--
         let expected = Node {
             id: 0,
-            span: root.restrict_range(0, 2),
+            span: root.restrict_range(0, 3),
             value: UnaryExpr {
                 kind: UnaryOp::Decrement,
                 expr: Box::new(Node {
                     id: 2,
-                    span: root.restrict_range(0, 0),
+                    span: root.restrict_range(0, 1),
                     value: Expr::Ident(Node {
                         id: 1,
-                        span: root.restrict_range(0, 0),
+                        span: root.restrict_range(0, 1),
                         value: "x".to_string(),
                     }),
                 }),

--- a/compiler/fluxc_parser/src/expr/operation/unary_expr.rs
+++ b/compiler/fluxc_parser/src/expr/operation/unary_expr.rs
@@ -1,12 +1,11 @@
-use fluxc_ast::{Expr, Ident, Literal, Node, UnaryExpr, UnaryOp};
-use fluxc_errors::CompilerError;
+use fluxc_ast::{Expr, Ident, Literal, UnaryExpr, UnaryOp};
 use pest::iterators::Pair;
 
-use crate::{unexpected_rule, Context, Parse, Rule};
+use crate::{unexpected_rule, Context, Parse, Rule, PResult};
 
 impl Parse for UnaryExpr {
     #[tracing::instrument]
-    fn parse<'i>(input: Pair<'i, Rule>, ctx: &mut Context) -> Result<Node<Self>, CompilerError> {
+    fn parse<'i>(input: Pair<'i, Rule>, ctx: &mut Context) -> PResult<Self> {
         debug_assert_eq!(input.as_rule(), Rule::unary_expr);
         let outer_span = input.as_span();
         let node = ctx.new_empty(input.as_span());

--- a/compiler/fluxc_parser/src/expr/operation/unary_expr.rs
+++ b/compiler/fluxc_parser/src/expr/operation/unary_expr.rs
@@ -1,7 +1,7 @@
 use fluxc_ast::{Expr, Ident, Literal, UnaryExpr, UnaryOp};
 use pest::iterators::Pair;
 
-use crate::{unexpected_rule, Context, Parse, Rule, PResult};
+use crate::{unexpected_rule, Context, PResult, Parse, Rule};
 
 impl Parse for UnaryExpr {
     #[tracing::instrument]
@@ -84,7 +84,6 @@ impl Parse for UnaryExpr {
 #[cfg(test)]
 mod tests {
     use fluxc_ast::{Expr, Node, UnaryExpr, UnaryOp};
-    use fluxc_span::Span;
     use pest::Parser;
     use pretty_assertions::assert_eq;
 
@@ -92,19 +91,20 @@ mod tests {
 
     #[test]
     fn parse_unary_expr() {
-        let mut ctx = Context::default();
+        let mut ctx = Context::from_str("x--");
+        let root = ctx.create_span();
         // x--
         let expected = Node {
             id: 0,
-            span: Span::new(0, 2),
+            span: root.restrict_range(0, 2),
             value: UnaryExpr {
                 kind: UnaryOp::Decrement,
                 expr: Box::new(Node {
                     id: 2,
-                    span: Span::new(0, 0),
+                    span: root.restrict_range(0, 0),
                     value: Expr::Ident(Node {
                         id: 1,
-                        span: Span::new(0, 0),
+                        span: root.restrict_range(0, 0),
                         value: "x".to_string(),
                     }),
                 }),

--- a/compiler/fluxc_parser/src/lib.rs
+++ b/compiler/fluxc_parser/src/lib.rs
@@ -9,6 +9,7 @@ use pest::{error::Error, iterators::Pair, Parser};
 mod expr;
 mod stmt;
 mod ty;
+mod span;
 
 /// Internal moduel to prevent leakage of the `Rule` type to external
 /// crates.

--- a/compiler/fluxc_parser/src/lib.rs
+++ b/compiler/fluxc_parser/src/lib.rs
@@ -1,9 +1,11 @@
 //! Defines the parser for Flux code.
 #![feature(option_result_contains)]
 
+use std::rc::Rc;
+
 use fluxc_ast::{Ident, Node, Stmt, AST};
 use fluxc_errors::CompilerError;
-use fluxc_span::Span;
+use fluxc_span::AsSpan;
 use pest::{error::Error, iterators::Pair, Parser};
 
 mod expr;
@@ -27,24 +29,28 @@ pub(crate) use parser::*;
 /// The parser context.
 #[derive(Debug)]
 struct Context {
+	/// The next ID to use for a new node.
     next_id: usize,
-}
-
-impl Default for Context {
-    fn default() -> Self {
-        Self { next_id: 0 }
-    }
+	/// The source text being parsed.
+	src: Rc<str>
 }
 
 impl Context {
+	/// Creates a new parser context.
+	pub fn from_str(src: &str) -> Self {
+		Self {
+			next_id: 0,
+			src: src.into()
+		}
+	}
     /// Create a new node from the given pair.
-    pub fn new_node<S: Into<Span>, T>(&mut self, span: S, value: T) -> Node<T> {
-        let node = Node::new(self.next_id, span.into(), value);
+    pub fn new_node<T, S: AsSpan>(&mut self, span: S, value: T) -> Node<T> {
+        let node = Node::new(self.next_id, span.as_span(&self.src), value);
         self.next_id += 1;
         node
     }
     /// Create an empty node.
-    pub fn new_empty<S: Into<Span>>(&mut self, span: S) -> Node<()> {
+    pub fn new_empty<S: AsSpan>(&mut self, span: S) -> Node<()> {
         self.new_node(span, ())
     }
 }
@@ -62,7 +68,7 @@ fn map_pest_error(error: Error<Rule>) -> CompilerError {
 #[tracing::instrument]
 pub fn parse(input: &str) -> Result<AST, CompilerError> {
     // create the parser context
-    let mut context = Context { next_id: 0 };
+    let mut context = Context::from_str(input);
     // call the pest parser
     let root =
         FluxParser::parse(Rule::flux, &input).map_err(map_pest_error)?.next().unwrap().into_inner();
@@ -72,10 +78,14 @@ pub fn parse(input: &str) -> Result<AST, CompilerError> {
     Ok(AST { stmts: stmts? })
 }
 
+
+/// The parser result type.
+type PResult<T> = Result<Node<T>, CompilerError>;
+
 /// Trait implemented by AST types that can be parsed from the Pest grammar AST.
 trait Parse: Sized {
     /// Parse an input Pair into an instance of this type.
-    fn parse<'i>(input: Pair<'i, Rule>, ctx: &mut Context) -> Result<Node<Self>, CompilerError>;
+    fn parse<'i>(input: Pair<'i, Rule>, ctx: &mut Context) -> PResult<Self>;
 }
 
 impl Parse for Ident {
@@ -83,7 +93,7 @@ impl Parse for Ident {
     fn parse<'i>(
         input: Pair<'i, Rule>,
         context: &mut Context,
-    ) -> Result<Node<Self>, CompilerError> {
+    ) -> PResult<Self> {
         Ok(context.new_node(input.as_span(), input.as_str().into()))
     }
 }

--- a/compiler/fluxc_parser/src/span.rs
+++ b/compiler/fluxc_parser/src/span.rs
@@ -1,0 +1,14 @@
+use fluxc_span::Span;
+use pest::iterators::Pair;
+
+use crate::Rule;
+
+/// Restrict the input span to that of the input pair.
+pub fn restrict_input<'i>(input: Pair<'i, Rule>, span: &Span) -> (Pair<'i, Rule>, Span) {
+    (input, span.restrict(input.as_span().start()..input.as_span().end()))
+}
+
+/// Restrict the input span to that of the second span.
+pub fn restrict<'i>(a: Span, b: pest::Span<'i>) -> Span {
+    a.restrict(b.start()..b.end())
+}

--- a/compiler/fluxc_parser/src/span.rs
+++ b/compiler/fluxc_parser/src/span.rs
@@ -5,7 +5,8 @@ use crate::Rule;
 
 /// Restrict the input span to that of the input pair.
 pub fn restrict_input<'i>(input: Pair<'i, Rule>, span: &Span) -> (Pair<'i, Rule>, Span) {
-    (input, span.restrict(input.as_span().start()..input.as_span().end()))
+    let span = span.restrict(input.as_span().start()..input.as_span().end());
+    (input, span)
 }
 
 /// Restrict the input span to that of the second span.

--- a/compiler/fluxc_parser/src/stmt/declaration.rs
+++ b/compiler/fluxc_parser/src/stmt/declaration.rs
@@ -1,15 +1,11 @@
-use fluxc_ast::{Declaration, Expr, Ident, Mutability, Node};
-use fluxc_errors::CompilerError;
+use fluxc_ast::{Declaration, Expr, Ident, Mutability};
 use pest::iterators::Pair;
 
-use crate::{Context, Parse, Rule};
+use crate::{Context, PResult, Parse, Rule};
 
 impl Parse for Declaration {
     #[tracing::instrument]
-    fn parse<'i>(
-        input: Pair<'i, Rule>,
-        context: &mut Context,
-    ) -> PResult<Self> {
+    fn parse<'i>(input: Pair<'i, Rule>, context: &mut Context) -> PResult<Self> {
         let node = context.new_empty(input.as_span());
         // declaration is either a let or a mutable declaration.
         let decl = match input.as_rule() {

--- a/compiler/fluxc_parser/src/stmt/declaration.rs
+++ b/compiler/fluxc_parser/src/stmt/declaration.rs
@@ -9,7 +9,7 @@ impl Parse for Declaration {
     fn parse<'i>(
         input: Pair<'i, Rule>,
         context: &mut Context,
-    ) -> Result<Node<Self>, CompilerError> {
+    ) -> PResult<Self> {
         let node = context.new_empty(input.as_span());
         // declaration is either a let or a mutable declaration.
         let decl = match input.as_rule() {

--- a/compiler/fluxc_parser/src/stmt/func_decl.rs
+++ b/compiler/fluxc_parser/src/stmt/func_decl.rs
@@ -16,7 +16,7 @@ impl Parse for FuncCall {
     fn parse<'i>(
         input: Pair<'i, crate::Rule>,
         ctx: &mut Context,
-    ) -> Result<Node<Self>, CompilerError> {
+    ) -> PResult<Self> {
         todo!()
     }
 }
@@ -26,7 +26,7 @@ impl Parse for ParenArgument {
     fn parse<'i>(
         input: Pair<'i, crate::Rule>,
         ctx: &mut Context,
-    ) -> Result<Node<Self>, CompilerError> {
+    ) -> PResult<Self> {
         debug_assert_eq!(input.as_rule(), Rule::func_decl_param);
         let node = ctx.new_empty(input.as_span());
         let mut inner = input.into_inner();
@@ -41,7 +41,7 @@ impl Parse for FuncDecl {
     fn parse<'i>(
         input: Pair<'i, crate::Rule>,
         ctx: &mut Context,
-    ) -> Result<Node<Self>, CompilerError> {
+    ) -> PResult<Self> {
         let span = input.as_span();
         let rule = input.as_rule();
         let mut inner = input.into_inner();

--- a/compiler/fluxc_parser/src/stmt/mod.rs
+++ b/compiler/fluxc_parser/src/stmt/mod.rs
@@ -1,5 +1,4 @@
-use fluxc_ast::{Declaration, Expr, FuncDecl, Node, Stmt};
-use fluxc_errors::CompilerError;
+use fluxc_ast::{Declaration, Expr, FuncDecl, Stmt};
 use pest::iterators::Pair;
 
 pub(crate) mod declaration;
@@ -10,14 +9,11 @@ pub use declaration::*;
 pub use func_decl::*;
 pub use module::*;
 
-use crate::{Context, Parse, Rule};
+use crate::{Context, PResult, Parse, Rule};
 
 impl Parse for Stmt {
     #[tracing::instrument]
-    fn parse<'i>(
-        input: Pair<'i, Rule>,
-        context: &mut Context,
-    ) -> PResult<Self> {
+    fn parse<'i>(input: Pair<'i, Rule>, context: &mut Context) -> PResult<Self> {
         debug_assert_eq!(input.as_rule(), Rule::statement);
         let node = context.new_empty(input.as_span());
         // statement rule has only one child

--- a/compiler/fluxc_parser/src/stmt/mod.rs
+++ b/compiler/fluxc_parser/src/stmt/mod.rs
@@ -17,7 +17,7 @@ impl Parse for Stmt {
     fn parse<'i>(
         input: Pair<'i, Rule>,
         context: &mut Context,
-    ) -> Result<Node<Self>, CompilerError> {
+    ) -> PResult<Self> {
         debug_assert_eq!(input.as_rule(), Rule::statement);
         let node = context.new_empty(input.as_span());
         // statement rule has only one child

--- a/compiler/fluxc_parser/src/stmt/module.rs
+++ b/compiler/fluxc_parser/src/stmt/module.rs
@@ -11,7 +11,7 @@ impl Parse for ImportedSymbol {
     fn parse<'i>(
         input: Pair<'i, Rule>,
         context: &mut Context,
-    ) -> Result<Node<Self>, CompilerError> {
+    ) -> PResult<Self> {
         todo!()
     }
 }
@@ -21,7 +21,7 @@ impl Parse for Import {
     fn parse<'i>(
         input: Pair<'i, Rule>,
         context: &mut Context,
-    ) -> Result<Node<Self>, CompilerError> {
+    ) -> PResult<Self> {
         todo!()
     }
 }
@@ -31,7 +31,7 @@ impl Parse for Export {
     fn parse<'i>(
         input: Pair<'i, Rule>,
         context: &mut Context,
-    ) -> Result<Node<Self>, CompilerError> {
+    ) -> PResult<Self> {
         todo!()
     }
 }

--- a/compiler/fluxc_parser/src/stmt/module.rs
+++ b/compiler/fluxc_parser/src/stmt/module.rs
@@ -1,37 +1,27 @@
 //! Contains data structures for representing imports and exports.
 
 use fluxc_ast::{Export, Import, ImportedSymbol};
-use fluxc_errors::CompilerError;
 use pest::iterators::Pair;
 
-use crate::{Context, Node, Parse, Rule};
+use crate::{Context, PResult, Parse, Rule};
 
 impl Parse for ImportedSymbol {
     #[tracing::instrument]
-    fn parse<'i>(
-        input: Pair<'i, Rule>,
-        context: &mut Context,
-    ) -> PResult<Self> {
+    fn parse<'i>(input: Pair<'i, Rule>, context: &mut Context) -> PResult<Self> {
         todo!()
     }
 }
 
 impl Parse for Import {
     #[tracing::instrument]
-    fn parse<'i>(
-        input: Pair<'i, Rule>,
-        context: &mut Context,
-    ) -> PResult<Self> {
+    fn parse<'i>(input: Pair<'i, Rule>, context: &mut Context) -> PResult<Self> {
         todo!()
     }
 }
 
 impl Parse for Export {
     #[tracing::instrument]
-    fn parse<'i>(
-        input: Pair<'i, Rule>,
-        context: &mut Context,
-    ) -> PResult<Self> {
+    fn parse<'i>(input: Pair<'i, Rule>, context: &mut Context) -> PResult<Self> {
         todo!()
     }
 }

--- a/compiler/fluxc_parser/src/ty.rs
+++ b/compiler/fluxc_parser/src/ty.rs
@@ -1,15 +1,10 @@
-use fluxc_ast::Node;
-use fluxc_errors::CompilerError;
 use fluxc_types::Type;
 use pest::iterators::Pair;
 
-use crate::{Context, Parse};
+use crate::{Context, PResult, Parse};
 
 impl Parse for Type {
-    fn parse<'i>(
-        input: Pair<'i, crate::parser::Rule>,
-        ctx: &mut Context,
-    ) -> PResult<Self> {
+    fn parse<'i>(input: Pair<'i, crate::parser::Rule>, ctx: &mut Context) -> PResult<Self> {
         todo!()
     }
 }

--- a/compiler/fluxc_parser/src/ty.rs
+++ b/compiler/fluxc_parser/src/ty.rs
@@ -9,7 +9,7 @@ impl Parse for Type {
     fn parse<'i>(
         input: Pair<'i, crate::parser::Rule>,
         ctx: &mut Context,
-    ) -> Result<Node<Self>, CompilerError> {
+    ) -> PResult<Self> {
         todo!()
     }
 }

--- a/compiler/fluxc_span/src/lib.rs
+++ b/compiler/fluxc_span/src/lib.rs
@@ -1,22 +1,26 @@
+use std::{rc::Rc, ops::Range};
+
 /// Small struct for indexing AST nodes to a particular slice within the source
 /// code. The span is byte-indexed, rather than character-indexed.
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Span {
     /// The start byte position of the span.
     pub start: usize,
     /// The end byte position of the span, inclusive.
     pub end: usize,
+	/// The source text of the span.
+	pub source: Rc<str>
 }
 
 impl Span {
     /// Create a new span.
-    pub fn new(start: usize, end: usize) -> Span {
-        Span { start, end }
+    pub fn from_src<S: AsRef<str>>(src: S, start: usize, end: usize) -> Span {
+        Span { source: src.as_ref().into(), start, end  }
     }
 
     /// Convert this span into a source code slice.
-    pub fn as_slice<'a>(&self, source: &'a str) -> &'a str {
-        &source[self.start..self.end]
+    pub fn as_slice(&self) -> &str {
+        &self.source[self.start..self.end]
     }
 
     /// Returns true if this span includes another.
@@ -28,17 +32,10 @@ impl Span {
     pub const fn overlaps(&self, other: &Span) -> bool {
         self.start <= other.end && self.end >= other.start
     }
-}
 
-impl From<pest::Span<'_>> for Span {
-    fn from(span: pest::Span) -> Self {
-        (&span).into()
-    }
-}
-
-impl From<&pest::Span<'_>> for Span {
-    fn from(span: &pest::Span<'_>) -> Self {
-        // -1 here to ensure that the end is inclusive
-        Span::new(span.start(), span.end() - 1)
-    }
+	pub fn restrict(&self, range: Range<usize>) -> Span {
+		let start = self.start.max(range.start);
+		let end = self.end.min(range.end);
+		Span::from_src(self.source.clone(), start, end)
+	}
 }

--- a/compiler/fluxc_span/src/lib.rs
+++ b/compiler/fluxc_span/src/lib.rs
@@ -1,4 +1,6 @@
-use std::{rc::Rc, ops::Range};
+use std::{rc::Rc, ops::Range, fmt::Debug};
+
+use pest::RuleType;
 
 /// Small struct for indexing AST nodes to a particular slice within the source
 /// code. The span is byte-indexed, rather than character-indexed.
@@ -8,19 +10,31 @@ pub struct Span {
     pub start: usize,
     /// The end byte position of the span, inclusive.
     pub end: usize,
-	/// The source text of the span.
-	pub source: Rc<str>
+	// The source text being parsed.
+	pub src: Rc<str>,
 }
 
 impl Span {
     /// Create a new span.
-    pub fn from_src<S: AsRef<str>>(src: S, start: usize, end: usize) -> Span {
-        Span { source: src.as_ref().into(), start, end  }
+    pub fn from_str<S: AsRef<str>>(src: S) -> Span {
+        Span { src: src.as_ref().into(), start: 0, end: src.as_ref().len() }
     }
+
+	// Restrict this span to the given range. If the span is already inside the range,
+	// it will be returned unchanged. If the span is outside the range, it will be
+	pub fn restrict<S: AsSpan>(&self, other: S) -> Span {
+		let span = other.as_span(&self.src);
+		self.restrict_range(span.start, span.end)
+	}
+
+	/// This method restricts the span to the given range.
+	pub fn restrict_range(&self, start: usize, end: usize) -> Span {
+		Span { src: self.src.clone(), start: start.max(self.start), end: end.min(self.end) }
+	}
 
     /// Convert this span into a source code slice.
     pub fn as_slice(&self) -> &str {
-        &self.source[self.start..self.end]
+        &self.src[self.start..self.end]
     }
 
     /// Returns true if this span includes another.
@@ -32,10 +46,41 @@ impl Span {
     pub const fn overlaps(&self, other: &Span) -> bool {
         self.start <= other.end && self.end >= other.start
     }
+}
 
-	pub fn restrict(&self, range: Range<usize>) -> Span {
-		let start = self.start.max(range.start);
-		let end = self.end.min(range.end);
-		Span::from_src(self.source.clone(), start, end)
+/// Trait implemented by types that can be converted to `fluxc::Span` instances,
+/// given some input source.
+pub trait AsSpan {
+	/// This method returns a new Span instance for the given input.
+	fn as_span(&self, src: &str) -> Span;
+}
+
+impl AsSpan for Range<usize> {
+    fn as_span(&self, src: &str) -> Span {
+        Span::from_str(src).restrict_range(self.start, self.end)
+    }
+}
+
+impl AsSpan for pest::Span<'_> {
+	fn as_span(&self, src: &str) -> Span {
+		Span::from_str(src).restrict_range(self.start(), self.end())
+	}
+}
+
+impl AsSpan for &pest::Span<'_> {
+	fn as_span(&self, src: &str) -> Span {
+		(*self).as_span(src)
+	}
+}
+
+impl <R: RuleType> AsSpan for pest::iterators::Pair<'_, R> {
+    fn as_span(&self, src: &str) -> Span {
+        pest::iterators::Pair::as_span(&self).as_span(src)
+    }
+}
+
+impl <R: RuleType> AsSpan for &pest::iterators::Pair<'_, R> {
+	fn as_span(&self, src: &str) -> Span {
+		pest::iterators::Pair::as_span(*self).as_span(src)
 	}
 }

--- a/compiler/fluxc_span/src/lib.rs
+++ b/compiler/fluxc_span/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{rc::Rc, ops::Range, fmt::Debug};
+use std::{fmt::Debug, ops::Range, rc::Rc};
 
 use pest::RuleType;
 
@@ -10,8 +10,8 @@ pub struct Span {
     pub start: usize,
     /// The end byte position of the span, inclusive.
     pub end: usize,
-	// The source text being parsed.
-	pub src: Rc<str>,
+    // The source text being parsed.
+    pub src: Rc<str>,
 }
 
 impl Span {
@@ -20,17 +20,18 @@ impl Span {
         Span { src: src.as_ref().into(), start: 0, end: src.as_ref().len() }
     }
 
-	// Restrict this span to the given range. If the span is already inside the range,
-	// it will be returned unchanged. If the span is outside the range, it will be
-	pub fn restrict<S: AsSpan>(&self, other: S) -> Span {
-		let span = other.as_span(&self.src);
-		self.restrict_range(span.start, span.end)
-	}
+    // Restrict this span to the given range. If the span is already inside the
+    // range, it will be returned unchanged. If the span is outside the range,
+    // it will be
+    pub fn restrict<S: AsSpan>(&self, other: S) -> Span {
+        let span = other.as_span(&self.src);
+        self.restrict_range(span.start, span.end)
+    }
 
-	/// This method restricts the span to the given range.
-	pub fn restrict_range(&self, start: usize, end: usize) -> Span {
-		Span { src: self.src.clone(), start: start.max(self.start), end: end.min(self.end) }
-	}
+    /// This method restricts the span to the given range.
+    pub fn restrict_range(&self, start: usize, end: usize) -> Span {
+        Span { src: self.src.clone(), start: start.max(self.start), end: end.min(self.end) }
+    }
 
     /// Convert this span into a source code slice.
     pub fn as_slice(&self) -> &str {
@@ -51,8 +52,8 @@ impl Span {
 /// Trait implemented by types that can be converted to `fluxc::Span` instances,
 /// given some input source.
 pub trait AsSpan {
-	/// This method returns a new Span instance for the given input.
-	fn as_span(&self, src: &str) -> Span;
+    /// This method returns a new Span instance for the given input.
+    fn as_span(&self, src: &str) -> Span;
 }
 
 impl AsSpan for Range<usize> {
@@ -62,25 +63,37 @@ impl AsSpan for Range<usize> {
 }
 
 impl AsSpan for pest::Span<'_> {
-	fn as_span(&self, src: &str) -> Span {
-		Span::from_str(src).restrict_range(self.start(), self.end())
-	}
+    fn as_span(&self, src: &str) -> Span {
+        Span::from_str(src).restrict_range(self.start(), self.end())
+    }
 }
 
 impl AsSpan for &pest::Span<'_> {
-	fn as_span(&self, src: &str) -> Span {
-		(*self).as_span(src)
-	}
+    fn as_span(&self, src: &str) -> Span {
+        (*self).as_span(src)
+    }
 }
 
-impl <R: RuleType> AsSpan for pest::iterators::Pair<'_, R> {
+impl<R: RuleType> AsSpan for pest::iterators::Pair<'_, R> {
     fn as_span(&self, src: &str) -> Span {
         pest::iterators::Pair::as_span(&self).as_span(src)
     }
 }
 
-impl <R: RuleType> AsSpan for &pest::iterators::Pair<'_, R> {
-	fn as_span(&self, src: &str) -> Span {
-		pest::iterators::Pair::as_span(*self).as_span(src)
-	}
+impl<R: RuleType> AsSpan for &pest::iterators::Pair<'_, R> {
+    fn as_span(&self, src: &str) -> Span {
+        pest::iterators::Pair::as_span(*self).as_span(src)
+    }
+}
+
+impl AsSpan for Span {
+    fn as_span(&self, _: &str) -> Span {
+        self.clone()
+    }
+}
+
+impl AsSpan for &Span {
+    fn as_span(&self, _: &str) -> Span {
+        (*self).clone()
+    }
 }


### PR DESCRIPTION
- Adds `Rc<str>` to every span instance.
- Allows spans to return a string slice representation.